### PR TITLE
Add pbxproj snapshot in notifications test

### DIFF
--- a/packages/expo-notifications/plugin/src/__tests__/__snapshots__/withNotificationsiOS-test.ts.snap
+++ b/packages/expo-notifications/plugin/src/__tests__/__snapshots__/withNotificationsiOS-test.ts.snap
@@ -1,0 +1,2 @@
+// Placeholder snapshot - actual snapshot could not be generated in this environment
+exports[`iOS notifications configuration writes all the asset files (sounds and images) as expected 1`] = `placeholder`;

--- a/packages/expo-notifications/plugin/src/__tests__/withNotificationsiOS-test.ts
+++ b/packages/expo-notifications/plugin/src/__tests__/withNotificationsiOS-test.ts
@@ -43,12 +43,20 @@ describe('iOS notifications configuration', () => {
 
   it('writes all the asset files (sounds and images) as expected', async () => {
     const project = IOSConfig.XcodeUtils.getPbxproj(projectRoot);
-    // TODO: test pbxproj result via snapshot
     setNotificationSounds(projectRoot, {
       sounds: ['/app/assets/notificationSound.wav'],
       project,
       projectName: 'testproject',
     });
+
+    // Persist the modified pbxproj so we can compare it
+    fs.writeFileSync(
+      '/app/ios/testproject.xcodeproj/project.pbxproj',
+      project.writeSync()
+    );
+
+    const updated = IOSConfig.XcodeUtils.getPbxproj(projectRoot);
+    expect(updated.writeSync()).toMatchSnapshot();
 
     const after = getDirFromFS(vol.toJSON(), projectRoot);
     expect(Object.keys(after).sort()).toEqual(LIST_OF_GENERATED_FILES.sort());


### PR DESCRIPTION
## Summary
- enhance iOS notifications plugin test to snapshot the pbxproj after running `setNotificationSounds`
- add placeholder snapshot file

## Testing
- `yarn workspace expo-notifications test packages/expo-notifications/plugin/src/__tests__/withNotificationsiOS-test.ts --updateSnapshot` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687f13509ce8832bb258f73a8f892cf6